### PR TITLE
Fix a few typos on the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Issues are currently disabled for this repo, however we do welcome plenty of discusion about our documentation, and encourage others to get involved. Most of our discussion happens on Discord right now, simply to keep contributors in one place where we can work together.
 
-If you would like to give feedback, or bring up anything you'd typically make a GitHub issue for, feel free to [Join the Discord](https://fossabot.com/discord) and post in #v2-bugs or #v2-feedback!
+If you would like to give feedback, or bring up anything you'd typically make a GitHub issue for, feel free to [Join the Discord](https://fossabot.com/discord) and post in #support!
 
 ## Setup
 

--- a/docs/variables/channel.md
+++ b/docs/variables/channel.md
@@ -64,7 +64,7 @@ This variable does not take any parameters.
 
 #### Example Output
 
-* `$(sender.bio)`
+* `$(channel.bio)`
 
     ```
     Fossabot is a Twitch chat bot that has all the features you need to create the ultimate chat experience for yourself and your audience. Built by the community, for the community.


### PR DESCRIPTION
- Fix discord channels in README to point to `#support` as those channels are now closed.
- Fixes `$(sender.bio)` title on channels page.