### PR TITLE
Add documentation for $(customapi) API endpoints

### DIFF
--- a/docs/variables/customapi.md
+++ b/docs/variables/customapi.md
@@ -132,6 +132,11 @@ GET https://api.fossabot.com/v2/customapi/context/<token>
 
 A valid token will return HTTP status code `200` with the following body:
 
+:::info `message` is a nullable field
+
+In the event the customapi request was dispatched from an automated action (such as a timer), `message` will be `null`.
+:::
+
 ```
 {
     "channel": {

--- a/docs/variables/customapi.md
+++ b/docs/variables/customapi.md
@@ -37,7 +37,7 @@ Use our [API endpoints](#api-endpoints) to validate whether a request originated
 
 Fossabot's proxy **does not** use a consistent IP range to send requests. You **cannot** rely on it for authenticating endpoints!
 
-We recommended that you use our [API Endpoints](#api-endpoints) to validate whether a given request actually came from Fossabot.
+We recommended that you use our [**API Endpoints**](#api-endpoints) to validate whether a given request actually came from Fossabot.
 
 **For that reason we do NOT print customapi URLs on public commands pages.**
 
@@ -45,18 +45,18 @@ We recommended that you use our [API Endpoints](#api-endpoints) to validate whet
 
 These headers are present in **all** requests.
 
-|              Name               |                                              Value                                               |
-| :-----------------------------: | :----------------------------------------------------------------------------------------------: |
-|     `x-fossabot-channelid`      |                          The internal **Fossabot ID** of a broadcaster.                          |
-| `x-fossabot-channeldisplayname` |         The uppercase version, or internationalized version of a broadcaster's username.         |
-|    `x-fossabot-channellogin`    |         The lowercase version of a broadcaster's username (otherwise known as _login_).          |
-|    `x-fossabot-channelslug`     |       The **Fossabot channel URL** of a broadcaster. Useful for linking to commands pages.       |
-|  `x-fossabot-channelprovider`   |                     The platform the request was sent from (e.g. `twitch`).                      |
-| `x-fossabot-channelproviderid`  |                      The platform ID (e.g. the Twitch ID) of a broadcaster.                      |
-|   `x-fossabot-customapitoken`   | Token that uniquely identifies this request. Use this with our [API endpoints](#api-endpoints).  |
-|     `x-fossabot-hasmessage`     | `true` or `false` depending on whether a message triggered this request (`false` if timer, etc). |
-|    `x-fossabot-validateurl`     |  Refer to [Validating requests](#validating-requests) for more information about this endpoint.  |
-|          `user-agent`           |                                       `Fossabot Web Proxy`                                       |
+|              Name               |                                                Value                                                 |
+| :-----------------------------: | :--------------------------------------------------------------------------------------------------: |
+|     `x-fossabot-channelid`      |                            The internal **Fossabot ID** of a broadcaster.                            |
+| `x-fossabot-channeldisplayname` |           The uppercase version, or internationalized version of a broadcaster's username.           |
+|    `x-fossabot-channellogin`    |           The lowercase version of a broadcaster's username (otherwise known as _login_).            |
+|    `x-fossabot-channelslug`     |         The **Fossabot channel URL** of a broadcaster. Useful for linking to commands pages.         |
+|  `x-fossabot-channelprovider`   |                       The platform the request was sent from (e.g. `twitch`).                        |
+| `x-fossabot-channelproviderid`  |                        The platform ID (e.g. the Twitch ID) of a broadcaster.                        |
+|   `x-fossabot-customapitoken`   | The token that uniquely identifies this request. Use this with our [API endpoints](#api-endpoints).  |
+|     `x-fossabot-hasmessage`     |   `true` or `false` depending on whether a message triggered this request (`false` if timer, etc).   |
+|    `x-fossabot-validateurl`     |    Refer to [Validating requests](#validating-requests) for more information about this endpoint.    |
+|          `user-agent`           |                                         `Fossabot Web Proxy`                                         |
 
 ### List of Message Headers
 
@@ -72,11 +72,11 @@ These headers are present in requests **sent from messages** and therefore attac
 
 ### API Endpoints
 
-Fossabot exposes two API endpoints that you may use to either validate that a given customapi request originated from Fossabot, or obtain more data that would you to customize how you respond to a given request.
+Fossabot exposes two API endpoints that you may use to either validate that a given customapi request originated from Fossabot, or to obtain more data that would allow you to customize how you respond to a given request.
 
-:::info These endpoints are ratelimited.
+:::info These endpoints are rate limited.
 
-Refer to [Ratelimits](#ratelimits) for more information.
+Refer to [**Rate Limits**](#ratelimits) for more information.
 :::
 
 :::caution Tokens expire after 60 seconds.
@@ -107,7 +107,7 @@ A valid token will result in HTTP status code `200` with the following body:
 }
 ```
 
-You may send a GET request to the value of `context_url` to obtain more data about the incoming request. Refer to [Getting context](#getting-context) for more information.
+You may send a `GET` request to the value of `context_url` to obtain more data about the incoming request. Refer to [**Getting context**](#getting-context) for more information.
 
 ##### Invalid token
 
@@ -205,9 +205,9 @@ An invalid token will return HTTP status code `400` with the following body:
 }
 ```
 
-#### Ratelimits
+#### Rate Limits
 
-Fossabot uses a [leaky bucket ratelimiter](https://en.wikipedia.org/wiki/Leaky_bucket) to protect its services from abuse. You will receive a `429` HTTP status code with the following body if you exceed the rate limit:
+Fossabot uses a **[leaky bucket](https://en.wikipedia.org/wiki/Leaky_bucket) rate limiter** to protect its services from abuse. You will receive a `429` HTTP status code with the following body if you exceed the rate limit:
 
 ```
 {
@@ -220,8 +220,8 @@ Fossabot uses a [leaky bucket ratelimiter](https://en.wikipedia.org/wiki/Leaky_b
 
 **Rate limits may change at any time.** Use the following headers to throttle your requests accordingly:
 
-|          Name           |                                               Value                                                |
-| :---------------------: | :------------------------------------------------------------------------------------------------: |
-|   `x-ratelimit-total`   |                              The total size of your ratelimit bucket                               |
-| `x-ratelimit-remaining` |                               The remaining requests in your bucket                                |
-|   `x-ratelimit-reset`   | A [unix timestamp](https://en.wikipedia.org/wiki/Unix_time) of when your bucket is fully refilled. |
+|          Name           |                                                 Value                                                   |
+| :---------------------: | :-----------------------------------------------------------------------------------------------------: |
+|   `x-ratelimit-total`   |                                The total size of your rate limit bucket.                                |
+| `x-ratelimit-remaining` |                                 The remaining requests in your bucket.                                  |
+|   `x-ratelimit-reset`   | A [unix timestamp](https://en.wikipedia.org/wiki/Unix_time) of when your bucket is completely refilled. |

--- a/docs/variables/customapi.md
+++ b/docs/variables/customapi.md
@@ -103,7 +103,7 @@ A valid token will result in HTTP status code `200` with the following body:
 
 ```
 {
- "context_url": "https://api.fossabot.com/v2/customapi/context/<token>"
+    "context_url": "https://api.fossabot.com/v2/customapi/context/<token>"
 }
 ```
 
@@ -115,10 +115,10 @@ An invalid token will return HTTP status code `400` with the following body:
 
 ```
 {
- "code": "token_invalid",
- "error": "Bad Request",
- "message": "Invalid token",
- "status": 400
+    "code": "token_invalid",
+    "error": "Bad Request",
+    "message": "Invalid token",
+    "status": 400
 }
 ```
 
@@ -134,56 +134,56 @@ A valid token will return HTTP status code `200` with the following body:
 
 ```
 {
- "channel": {
-  "id": "1",
-  "login": "aiden",
-  "display_name": "Aiden",
-  "avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/aiden-profile_image-6d03ccc5d668cc80-300x300.jpeg",
-  "slug": "aiden",
-  "broadcaster_type": "affiliate",
-  "provider": "twitch",
-  "provider_id": "87763385",
-  "created_at": "2021-07-10T04:20:05.599789Z",
-  "stream_timestamp": "2022-09-17T19:17:27Z",
-  "is_live": true
- },
- "message": {
-  "id": "ae9a4e3e-d495-4d75-aec6-8965e7c4ccd0",
-  "content": "!testcommand",
-  "provider": "twitch",
-  "user": {
-   "provider_id": "87763385",
-   "login": "aiden",
-   "display_name": "Aiden",
-   "roles": [
-    {
-     "id": "1",
-     "name": "Broadcaster",
-     "type": "broadcaster"
+    "channel": {
+        "id": "1",
+        "login": "aiden",
+        "display_name": "Aiden",
+        "avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/aiden-profile_image-6d03ccc5d668cc80-300x300.jpeg",
+        "slug": "aiden",
+        "broadcaster_type": "affiliate",
+        "provider": "twitch",
+        "provider_id": "87763385",
+        "created_at": "2021-07-10T04:20:05.599789Z",
+        "stream_timestamp": "2022-09-17T19:17:27Z",
+        "is_live": true
     },
-    {
-     "id": "3",
-     "name": "Moderator",
-     "type": "moderator"
-    },
-    {
-     "id": "5",
-     "name": "Subscriber",
-     "type": "subscriber"
-    },
-    {
-     "id": "269",
-     "name": "test",
-     "type": "custom"
-    },
-    {
-     "id": "14",
-     "name": "Admin",
-     "type": "custom"
+    "message": {
+        "id": "ae9a4e3e-d495-4d75-aec6-8965e7c4ccd0",
+        "content": "!testcommand",
+        "provider": "twitch",
+        "user": {
+            "provider_id": "87763385",
+            "login": "aiden",
+            "display_name": "Aiden",
+            "roles": [
+                {
+                    "id": "1",
+                    "name": "Broadcaster",
+                    "type": "broadcaster"
+                },
+                {
+                    "id": "3",
+                    "name": "Moderator",
+                    "type": "moderator"
+                },
+                {
+                    "id": "5",
+                    "name": "Subscriber",
+                    "type": "subscriber"
+                },
+                {
+                    "id": "269",
+                    "name": "test",
+                    "type": "custom"
+                },
+                {
+                    "id": "14",
+                    "name": "Admin",
+                    "type": "custom"
+                }
+            ]
+        }
     }
-   ]
-  }
- }
 }
 ```
 
@@ -193,10 +193,10 @@ An invalid token will return HTTP status code `400` with the following body:
 
 ```
 {
- "code": "token_invalid",
- "error": "Bad Request",
- "message": "Invalid token",
- "status": 400
+    "code": "token_invalid",
+    "error": "Bad Request",
+    "message": "Invalid token",
+    "status": 400
 }
 ```
 
@@ -206,10 +206,10 @@ Fossabot uses a [leaky bucket ratelimiter](https://en.wikipedia.org/wiki/Leaky_b
 
 ```
 {
- "code": "ratelimit",
- "error": "Too Many Requests",
- "message": "You are being rate limited.",
- "status": 429
+    "code": "ratelimit",
+    "error": "Too Many Requests",
+    "message": "You are being rate limited.",
+    "status": 429
 }
 ```
 

--- a/docs/variables/customapi.md
+++ b/docs/variables/customapi.md
@@ -103,7 +103,7 @@ A valid token will result in HTTP status code `200` with the following body:
 
 ```
 {
-	"context_url": "https://api.fossabot.com/v2/customapi/context/<token>"
+ "context_url": "https://api.fossabot.com/v2/customapi/context/<token>"
 }
 ```
 
@@ -115,10 +115,10 @@ An invalid token will return HTTP status code `400` with the following body:
 
 ```
 {
-	"code": "token_invalid",
-	"error": "Bad Request",
-	"message": "Invalid token",
-	"status": 400
+ "code": "token_invalid",
+ "error": "Bad Request",
+ "message": "Invalid token",
+ "status": 400
 }
 ```
 
@@ -134,56 +134,56 @@ A valid token will return HTTP status code `200` with the following body:
 
 ```
 {
-	"channel": {
-		"id": "1",
-		"login": "aiden",
-		"display_name": "Aiden",
-		"avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/aiden-profile_image-6d03ccc5d668cc80-300x300.jpeg",
-		"slug": "aiden",
-		"broadcaster_type": "affiliate",
-		"provider": "twitch",
-		"provider_id": "87763385",
-		"created_at": "2021-07-10T04:20:05.599789Z",
-		"stream_timestamp": "2022-09-17T19:17:27Z",
-		"is_live": true
-	},
-	"message": {
-		"id": "ae9a4e3e-d495-4d75-aec6-8965e7c4ccd0",
-		"content": "!testcommand",
-		"provider": "twitch",
-		"user": {
-			"provider_id": "87763385",
-			"login": "aiden",
-			"display_name": "Aiden",
-			"roles": [
-				{
-					"id": "1",
-					"name": "Broadcaster",
-					"type": "broadcaster"
-				},
-				{
-					"id": "3",
-					"name": "Moderator",
-					"type": "moderator"
-				},
-				{
-					"id": "5",
-					"name": "Subscriber",
-					"type": "subscriber"
-				},
-				{
-					"id": "269",
-					"name": "test",
-					"type": "custom"
-				},
-				{
-					"id": "14",
-					"name": "Admin",
-					"type": "custom"
-				}
-			]
-		}
-	}
+ "channel": {
+  "id": "1",
+  "login": "aiden",
+  "display_name": "Aiden",
+  "avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/aiden-profile_image-6d03ccc5d668cc80-300x300.jpeg",
+  "slug": "aiden",
+  "broadcaster_type": "affiliate",
+  "provider": "twitch",
+  "provider_id": "87763385",
+  "created_at": "2021-07-10T04:20:05.599789Z",
+  "stream_timestamp": "2022-09-17T19:17:27Z",
+  "is_live": true
+ },
+ "message": {
+  "id": "ae9a4e3e-d495-4d75-aec6-8965e7c4ccd0",
+  "content": "!testcommand",
+  "provider": "twitch",
+  "user": {
+   "provider_id": "87763385",
+   "login": "aiden",
+   "display_name": "Aiden",
+   "roles": [
+    {
+     "id": "1",
+     "name": "Broadcaster",
+     "type": "broadcaster"
+    },
+    {
+     "id": "3",
+     "name": "Moderator",
+     "type": "moderator"
+    },
+    {
+     "id": "5",
+     "name": "Subscriber",
+     "type": "subscriber"
+    },
+    {
+     "id": "269",
+     "name": "test",
+     "type": "custom"
+    },
+    {
+     "id": "14",
+     "name": "Admin",
+     "type": "custom"
+    }
+   ]
+  }
+ }
 }
 ```
 
@@ -193,10 +193,10 @@ An invalid token will return HTTP status code `400` with the following body:
 
 ```
 {
-	"code": "token_invalid",
-	"error": "Bad Request",
-	"message": "Invalid token",
-	"status": 400
+ "code": "token_invalid",
+ "error": "Bad Request",
+ "message": "Invalid token",
+ "status": 400
 }
 ```
 
@@ -206,10 +206,10 @@ Fossabot uses a [leaky bucket ratelimiter](https://en.wikipedia.org/wiki/Leaky_b
 
 ```
 {
-	"code": "ratelimit",
-	"error": "Too Many Requests",
-	"message": "You are being rate limited.",
-	"status": 429
+ "code": "ratelimit",
+ "error": "Too Many Requests",
+ "message": "You are being rate limited.",
+ "status": 429
 }
 ```
 

--- a/docs/variables/customapi.md
+++ b/docs/variables/customapi.md
@@ -8,7 +8,7 @@ Returns the response of a HTTP GET request to a specified URL.
 
 #### Parameters
 
-This variable takes **one** *required* parameter that is a **URL** to send the HTTP GET request to.
+This variable takes **one** _required_ parameter that is a **URL** to send the HTTP GET request to.
 
 #### Example Output
 
@@ -16,11 +16,11 @@ There is no example output as it solely depends on what the requested URL return
 
 #### Error Output
 
-* In case an invalid URL is provided, or the remote server cannot be reached, returns the following:
+- In case an invalid URL is provided, or the remote server cannot be reached, returns the following:
 
-    ```
-    [Error: Failed to connect to remote server.]
-    ```
+  ```
+  [Error: Failed to connect to remote server.]
+  ```
 
 ### Developers
 
@@ -28,11 +28,16 @@ There is no example output as it solely depends on what the requested URL return
 
 Fossabot also sends multiple custom HTTP headers that you can use to build deeper integrations, a list of them can be found below.
 
+:::tip
+
+Use our [API endpoints](#api-endpoints) to validate whether a request originated from Fossabot, or obtain more data about the request.
+:::
+
 ### IP Ranges
 
 Fossabot's proxy **does not** use a consistent IP range to send requests. You **cannot** rely on it for authenticating endpoints!
 
-We recommended that you include a key query parameter or something else to authenticate users.
+We recommended that you use our [API Endpoints](#api-endpoints) to validate whether a given request actually came from Fossabot.
 
 **For that reason we do NOT print customapi URLs on public commands pages.**
 
@@ -40,16 +45,18 @@ We recommended that you include a key query parameter or something else to authe
 
 These headers are present in **all** requests.
 
-|              Name               |                                             Value                                                |
+|              Name               |                                              Value                                               |
 | :-----------------------------: | :----------------------------------------------------------------------------------------------: |
 |     `x-fossabot-channelid`      |                          The internal **Fossabot ID** of a broadcaster.                          |
-| `x-fossabot-channeldisplayname` |        The uppercase version, or internationalized version of a broadcaster's username.          |
-|    `x-fossabot-channellogin`    |         The lowercase version of a broadcaster's username (otherwise known as *login*).          |
+| `x-fossabot-channeldisplayname` |         The uppercase version, or internationalized version of a broadcaster's username.         |
+|    `x-fossabot-channellogin`    |         The lowercase version of a broadcaster's username (otherwise known as _login_).          |
 |    `x-fossabot-channelslug`     |       The **Fossabot channel URL** of a broadcaster. Useful for linking to commands pages.       |
 |  `x-fossabot-channelprovider`   |                     The platform the request was sent from (e.g. `twitch`).                      |
 | `x-fossabot-channelproviderid`  |                      The platform ID (e.g. the Twitch ID) of a broadcaster.                      |
+|   `x-fossabot-customapitoken`   | Token that uniquely identifies this request. Use this with our [API endpoints](#api-endpoints).  |
 |     `x-fossabot-hasmessage`     | `true` or `false` depending on whether a message triggered this request (`false` if timer, etc). |
-|          `user-agent`           |                                      `Fossabot Web Proxy`                                        |
+|    `x-fossabot-validateurl`     |  Refer to [Validating requests](#validating-requests) for more information about this endpoint.  |
+|          `user-agent`           |                                       `Fossabot Web Proxy`                                       |
 
 ### List of Message Headers
 
@@ -57,8 +64,159 @@ These headers are present in requests **sent from messages** and therefore attac
 
 |                 Name                 |                                                                    Value                                                                     |
 | :----------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------: |
-|       `x-fossabot-message-id`        |                                                 The message ID from the provider (e.g. Twitch).                                              |
-|    `x-fossabot-message-userlogin`    |                                The lowercase version of the sender's username (otherwise known as *login*).                                  |
+|       `x-fossabot-message-id`        |                                               The message ID from the provider (e.g. Twitch).                                                |
+|    `x-fossabot-message-userlogin`    |                                 The lowercase version of the sender's username (otherwise known as _login_).                                 |
 | `x-fossabot-message-userdisplayname` |                                The uppercase version, or internationalized version of the sender's username.                                 |
 |  `x-fossabot-message-userprovider`   | The platform the message was sent from by the user (this is useful if a Discord user toggles a Twitch command through the Discord bot, etc). |
-| `x-fossabot-message-userproviderid`  |                                               The platform ID (e.g. the Twitch ID) of the sender.                                            |
+| `x-fossabot-message-userproviderid`  |                                             The platform ID (e.g. the Twitch ID) of the sender.                                              |
+
+### API Endpoints
+
+Fossabot exposes two API endpoints that you may use to either validate that a given customapi request originated from Fossabot, or obtain more data that would you to customize how you respond to a given request.
+
+:::info These endpoints are ratelimited.
+
+Refer to [Ratelimits](#ratelimits) for more information.
+:::
+
+:::caution Tokens expire after 60 seconds.
+
+You will receive a `token_invalid` error when sending a request to these endpoints if the token has expired.
+:::
+
+#### Validating requests
+
+:::info This is a single use endpoint.
+
+This means that you will only receive a valid token response the first time you call this endpoint. If you call this endpoint twice using the same token, the second request will return an error.
+:::
+
+Fossabot exposes a **single use endpoint** to let you validate whether a given customapi request actually came from Fossabot.
+
+```
+GET https://api.fossabot.com/v2/customapi/validate/<token>
+```
+
+##### Valid token
+
+A valid token will result in HTTP status code `200` with the following body:
+
+```
+{
+	"context_url": "https://api.fossabot.com/v2/customapi/context/<token>"
+}
+```
+
+You may send a GET request to the value of `context_url` to obtain more data about the incoming request. Refer to [Getting context](#getting-context) for more information.
+
+##### Invalid token
+
+An invalid token will return HTTP status code `400` with the following body:
+
+```
+{
+	"code": "token_invalid",
+	"error": "Bad Request",
+	"message": "Invalid token",
+	"status": 400
+}
+```
+
+#### Getting context
+
+```
+GET https://api.fossabot.com/v2/customapi/context/<token>
+```
+
+#### Valid token
+
+A valid token will return HTTP status code `200` with the following body:
+
+```
+{
+	"channel": {
+		"id": "1",
+		"login": "aiden",
+		"display_name": "Aiden",
+		"avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/aiden-profile_image-6d03ccc5d668cc80-300x300.jpeg",
+		"slug": "aiden",
+		"broadcaster_type": "affiliate",
+		"provider": "twitch",
+		"provider_id": "87763385",
+		"created_at": "2021-07-10T04:20:05.599789Z",
+		"stream_timestamp": "2022-09-17T19:17:27Z",
+		"is_live": true
+	},
+	"message": {
+		"id": "ae9a4e3e-d495-4d75-aec6-8965e7c4ccd0",
+		"content": "!testcommand",
+		"provider": "twitch",
+		"user": {
+			"provider_id": "87763385",
+			"login": "aiden",
+			"display_name": "Aiden",
+			"roles": [
+				{
+					"id": "1",
+					"name": "Broadcaster",
+					"type": "broadcaster"
+				},
+				{
+					"id": "3",
+					"name": "Moderator",
+					"type": "moderator"
+				},
+				{
+					"id": "5",
+					"name": "Subscriber",
+					"type": "subscriber"
+				},
+				{
+					"id": "269",
+					"name": "test",
+					"type": "custom"
+				},
+				{
+					"id": "14",
+					"name": "Admin",
+					"type": "custom"
+				}
+			]
+		}
+	}
+}
+```
+
+##### Invalid token
+
+An invalid token will return HTTP status code `400` with the following body:
+
+```
+{
+	"code": "token_invalid",
+	"error": "Bad Request",
+	"message": "Invalid token",
+	"status": 400
+}
+```
+
+#### Ratelimits
+
+Fossabot uses a [leaky bucket ratelimiter](https://en.wikipedia.org/wiki/Leaky_bucket) to protect its services from abuse. You will receive a `429` HTTP status code with the following body if you exceed the rate limit:
+
+```
+{
+	"code": "ratelimit",
+	"error": "Too Many Requests",
+	"message": "You are being rate limited.",
+	"status": 429
+}
+```
+
+**Rate limits may change at any time.** Use the following headers to throttle your requests accordingly:
+
+|          Name           |                                               Value                                                |
+| :---------------------: | :------------------------------------------------------------------------------------------------: |
+|   `x-ratelimit-total`   |                              The total size of your ratelimit bucket                               |
+| `x-ratelimit-remaining` |                               The remaining requests in your bucket                                |
+|   `x-ratelimit-reset`   | A [unix timestamp](https://en.wikipedia.org/wiki/Unix_time) of when your bucket is fully refilled. |

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
     "lint": "markdownlint-cli2 \"**/*.md\" \"#node_modules\"",
+    "format": "markdownlint-cli2-fix \"**/*.md\" \"#node_modules\"",
     "audit-fix": "npm i --package-lock-only && npm audit fix && rm yarn.lock && yarn import && rm package-lock.json"
   },
   "dependencies": {


### PR DESCRIPTION
We now expose tokens that allow you to validate, and obtain more data about an incoming `$(customapi)` request.

This documents our first ever publicly available endpoints on Fossabot - and how to use them.

Also added `yarn format` to auto fix linting issues.