### PR TITLE
Remove $(channel.views) from docs

### DIFF
--- a/docs/variables/channel.md
+++ b/docs/variables/channel.md
@@ -279,19 +279,3 @@ This variable does not take any parameters.
     ```
     [Error: Stream is offline.]
     ```
-
-## $(channel.views)
-
-Returns the total number of views that a broadcaster has on their profile page.
-
-#### Parameters
-
-This variable does not take any parameters.
-
-#### Example Output
-
-* `$(channel.views)`
-
-    ```
-    100354
-    ```


### PR DESCRIPTION
I removed `$(channel.views)` as the field it depends on is being deprecated in Twitch API anyways.