### PR TITLE
adds $(valorant.rank) + $(leagueoflegends) russia region

### DIFF
--- a/docs/variables/leagueoflegends.md
+++ b/docs/variables/leagueoflegends.md
@@ -22,6 +22,7 @@ This variable takes **two** *required* parameters. The **first** parameter is th
   * `oce` - *(Oceania)*
   * `pbe` - *(Public Beta Environment)*
   * `ph` - *(Philippines)*
+  * `ru` - *(Russia)*
   * `sg` - *(Singapore)*
   * `th` - *(Thailand)*
   * `tw` - *(Taiwan)*

--- a/docs/variables/valorant.md
+++ b/docs/variables/valorant.md
@@ -36,7 +36,7 @@ This variable does not take any parameters.
 
 #### Example Output
 
-* `$(valorant.rank)` *(all games modes, **without** custom games)*
+* `$(valorant.rank)`
 
     ```
     Platinum 1

--- a/docs/variables/valorant.md
+++ b/docs/variables/valorant.md
@@ -26,6 +26,42 @@ This variable will only function if a broadcaster has authorized and connected a
   * `include_custom` - *(adds custom games to be considered)*
   * `custom_only` - *(limits the considered games to **custom games only**)*
 
+## $(valorant.rank)
+
+Returns the current competitive rank of the broadcaster.
+
+#### Parameters
+
+This variable does not take any parameters.
+
+#### Example Output
+
+* `$(valorant.rank)` *(all games modes, **without** custom games)*
+
+    ```
+    Platinum 1
+    ```
+
+#### Error Output
+
+* In case we are unable to retrieve a response from [Riot](https://riotgames.com)'s API:
+
+    ```
+    [Error: Riot API returned an error.]
+    ```
+
+* In case we are unable to resolve the Riot's internal competitive type to a label:
+
+    ```
+    <unknown>
+    ```
+
+* In case the Riot account does not have any competitive match history:
+
+    ```
+    [Error: Cannot determine rank - account does not appear to have any competitive match history.]
+    ```
+
 ## $(valorant.stream_wins)
 
 Returns the number of games that ended in a win for a specified game mode(s) during the current stream session.


### PR DESCRIPTION
* Adds `$(valorant.rank)` to docs, found a hacky way to pull it.

* `ru` region was missing in `$(leagueoflegends)` docs and someone asked about that today... we've always had support, so just added it to the docs.