### PR TITLE
Migrate `$(leagueoflegends)` to Riot IDs

### DIFF
--- a/docs/variables/leagueoflegends.md
+++ b/docs/variables/leagueoflegends.md
@@ -4,11 +4,22 @@ id: leagueoflegends
 
 # $(leagueoflegends)
 
-Returns the current [**League of Legends**](https://leagueoflegends.com) league points and rank of a summoner.
+Returns the current [**League of Legends**](https://leagueoflegends.com) league points and rank of a player.
+
+:::info Riot ID transition
+
+Riot have [**announced**](https://www.riotgames.com/en/news/summoner-name-riot-ID) their intention to migrate from Summoner Names to [**Riot IDs**](https://support-leagueoflegends.riotgames.com/hc/en-us/articles/360041788533-Riot-ID-FAQ).
+
+In response, Fossabot is changing the syntax of `$(leagueoflegends)`. From `$(leagueoflegends <region> <summoner name>)` to `$(leagueoflegends <region> <Riot#ID>)`.
+
+For example, `$(leagueoflegends na WallisDev)` becomes `$(leagueoflegends na Aiden#Dev)`.
+
+The variable will continue to support both methods, but as Riot phases out the use of Summoner Names, the legacy functionality will break.
+:::
 
 #### Parameters
 
-This variable takes **two** *required* parameters. The **first** parameter is the **account region** of a summoner, and the **second** parameter is the **public name** of a summoner.
+This variable takes **two** *required* parameters. The **first** parameter is the **account region** of a player, and the **second** parameter is the [**Riot ID**](https://support-leagueoflegends.riotgames.com/hc/en-us/articles/360041788533-Riot-ID-FAQ) of the player.
 
 * **Supported Account Regions**
   * `br` - *(Brazil)*
@@ -31,15 +42,21 @@ This variable takes **two** *required* parameters. The **first** parameter is th
 
 #### Example Output
 
-* `$(leagueoflegends kr SKT T1 Faker)`
+* `$(leagueoflegends kr Hide on bush#KR1)`
 
     ```
-    SKT T1 Faker is currently Challenger I 1102 LP
+    Hide on bush is currently Grandmaster I 789 LP
     ```
 
 #### Error Output
 
-* In case a summoner cannot be found, returns the following:
+* In case a Riot ID is not found, returns the following:
+
+    ```
+    [Error: Riot ID not found]
+    ```
+
+* In case a summoner cannot be found in the given region, returns the following:
 
     ```
     [Error: Summoner not found.] 

--- a/docs/variables/leagueoflegends.md
+++ b/docs/variables/leagueoflegends.md
@@ -53,7 +53,7 @@ This variable takes **two** *required* parameters. The **first** parameter is th
 * In case a Riot ID is not found, returns the following:
 
     ```
-    [Error: Riot ID not found]
+    [Error: Riot ID not found.]
     ```
 
 * In case a summoner cannot be found in the given region, returns the following:

--- a/docs/variables/leagueoflegends.md
+++ b/docs/variables/leagueoflegends.md
@@ -8,7 +8,7 @@ Returns the current [**League of Legends**](https://leagueoflegends.com) league 
 
 :::info Riot ID transition
 
-Riot have [**announced**](https://www.riotgames.com/en/news/summoner-name-riot-ID) their intention to migrate from Summoner Names to [**Riot IDs**](https://support-leagueoflegends.riotgames.com/hc/en-us/articles/360041788533-Riot-ID-FAQ).
+Riot has [**announced**](https://www.riotgames.com/en/news/summoner-name-riot-ID) their intention to migrate from Summoner Names to [**Riot IDs**](https://support-leagueoflegends.riotgames.com/hc/en-us/articles/360041788533-Riot-ID-FAQ).
 
 In response, Fossabot is changing the syntax of `$(leagueoflegends)`. From `$(leagueoflegends <region> <summoner name>)` to `$(leagueoflegends <region> <Riot#ID>)`.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6689,15 +6689,10 @@ multicast-dns@^7.2.5:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
 
-nanoid@^3.1.30:
-  version "3.1.32"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.1.32.tgz"
-  integrity sha512-F8mf7R3iT9bvThBoW4tGXhXFHCctyCiUUPrWF8WaTqa3h96d9QybkSeba43XVOOE3oiLfkVDe4bT8MeGmkrTxw==
-
-nanoid@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -7390,21 +7385,12 @@ postcss-zindex@^5.1.0:
   resolved "https://registry.yarnpkg.com/postcss-zindex/-/postcss-zindex-5.1.0.tgz#4a5c7e5ff1050bd4c01d95b1847dfdcc58a496ff"
   integrity sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==
 
-postcss@^8.3.11:
-  version "8.4.5"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz"
-  integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
+postcss@^8.3.11, postcss@^8.4.14, postcss@^8.4.17, postcss@^8.4.7:
+  version "8.4.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
-    nanoid "^3.1.30"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.1"
-
-postcss@^8.4.14, postcss@^8.4.17, postcss@^8.4.7:
-  version "8.4.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.18.tgz#6d50046ea7d3d66a85e0e782074e7203bc7fbca2"
-  integrity sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==
-  dependencies:
-    nanoid "^3.3.4"
+    nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
@@ -8329,11 +8315,6 @@ sort-css-media-queries@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/sort-css-media-queries/-/sort-css-media-queries-2.1.0.tgz#7c85e06f79826baabb232f5560e9745d7a78c4ce"
   integrity sha512-IeWvo8NkNiY2vVYdPa27MCQiR0MN0M80johAYFVxWWXQ44KU84WNxjslwBHmc/7ZL2ccwkM7/e6S5aiKZXm7jA==
-
-source-map-js@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz"
-  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
 
 source-map-js@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Riot announced their intention to move away from Summoner Names to Riot IDs. [API consumers are also required to migrate](https://developer.riotgames.com/docs/lol#summoner-names-to-riot-ids).

Fossabot has been migrated internally to support this change, and supports both legacy Summoner Names and the new Riot ID system in the same variable - but updating docs to reflect that, and adding a notice for a little while.