### PR TITLE
Adds `$(twitchreward.redeemer_position)`

### DIFF
--- a/docs/variables/twitchreward.md
+++ b/docs/variables/twitchreward.md
@@ -4,6 +4,12 @@ id: twitchreward
 
 # $(twitchreward)
 
+:::note
+
+Due to limitations imposed by the [**Twitch API**](https://dev.twitch.tv/docs/api/reference/#get-custom-reward-redemption), Fossabot is only able to return metadata for rewards created through the [**Fossabot dashboard**](https://fossabot.com/login). Create them through Fossabot's `Channel Points` page.
+
+:::
+
 Returns a range metadata around a given [**Twitch Channel Point Reward**](https://help.twitch.tv/s/article/channel-points-guide).
 
 ## $(twitchreward)
@@ -32,6 +38,20 @@ This variable takes *one* **required** parameter that is the **name of the [Twit
 
     ```
     250+
+    ```
+
+#### Error Output
+
+* In case the reward was not found:
+
+    ```
+    [Error: Unable to find a reward with that name.]
+    ```
+
+* In case the reward was **not** created through the [**Fossabot dashboard**](https://fossabot.com/login):
+
+    ```
+    [Error: Unable to access reward, make sure you create it through fossabot.com]
     ```
 
 ## $(twitchreward.queue_depth)
@@ -70,6 +90,91 @@ This variable takes *one* **required** parameter that is the **name of the [Twit
     [Error: Unable to find a reward with that name.]
     ```
 
+* In case the reward was **not** created through the [**Fossabot dashboard**](https://fossabot.com/login):
+
+    ```
+    [Error: Unable to access reward, make sure you create it through fossabot.com]
+    ```
+
+## $(twitchreward.redeemer_position)
+
+Returns the position for the message sender in the redemption queue.
+
+#### Parameters
+
+This variable takes *one* **required** parameter that is the **name of the [Twitch Channel Point Reward](https://help.twitch.tv/s/article/channel-points-guide)** to fetch the metadata of.
+
+#### Example Output
+
+* `$(twitchreward.redeemer_position Play a game of VALORANT with me!)`
+
+    ```
+    2
+    ```
+
+#### Error Output
+
+* In case the reward was not found:
+
+    ```
+    [Error: Unable to find a reward with that name.]
+    ```
+
+* In case the reward was **not** created through the [**Fossabot dashboard**](https://fossabot.com/login):
+
+    ```
+    [Error: Unable to access reward, make sure you create it through fossabot.com]
+    ```
+
+* In case the user does **not** have a pending redemption in the rewards queue:
+
+    ```
+    [Error: User is not in queue!]
+    ```
+
+
+## $(twitchreward.redeemer_position.USERNAME_OR_ID)
+
+Returns the position for a specific user in the redemption queue. Replace `USERNAME_OR_ID` with another variable, such as [**$(user)**](/variables/user), or a hardcoded value. You may specifiy **either** a user ID, or username.
+
+#### Parameters
+
+This variable takes *one* **required** parameter that is the **name of the [Twitch Channel Point Reward](https://help.twitch.tv/s/article/channel-points-guide)** to fetch the metadata of.
+
+#### Example Output
+
+* `$(twitchreward.redeemer_position.aiden Play a game of VALORANT with me!)`
+
+    ```
+    2
+    ```
+
+* `$(twitchreward.redeemer_position.87763385 Play a game of VALORANT with me!)`
+
+    ```
+    2
+    ```
+
+#### Error Output
+
+* In case the reward was not found:
+
+    ```
+    [Error: Unable to find a reward with that name.]
+    ```
+
+* In case the reward was **not** created through the [**Fossabot dashboard**](https://fossabot.com/login):
+
+    ```
+    [Error: Unable to access reward, make sure you create it through fossabot.com]
+    ```
+
+* In case the user does **not** have a pending redemption in the rewards queue:
+
+    ```
+    [Error: User is not in queue!]
+    ```
+
 ## $(twitchreward.redeemers)
 
 Returns the 5 oldest redeemers in the queue, sorted by oldest redemption first.
@@ -92,6 +197,12 @@ This variable takes *one* **required** parameter that is the **name of the [Twit
 
     ```
     [Error: Unable to find a reward with that name.]
+    ```
+
+* In case the reward was **not** created through the [**Fossabot dashboard**](https://fossabot.com/login):
+
+    ```
+    [Error: Unable to access reward, make sure you create it through fossabot.com]
     ```
 
 ## $(twitchreward.redeemers.COUNT)
@@ -128,4 +239,10 @@ This variable takes *one* **required** parameter that is the **name of the [Twit
 
     ```
     [Error: Unable to find a reward with that name.]
+    ```
+
+* In case the reward was **not** created through the [**Fossabot dashboard**](https://fossabot.com/login):
+
+    ```
+    [Error: Unable to access reward, make sure you create it through fossabot.com]
     ```

--- a/docs/variables/twitchreward.md
+++ b/docs/variables/twitchreward.md
@@ -132,7 +132,6 @@ This variable takes *one* **required** parameter that is the **name of the [Twit
     [Error: User is not in queue!]
     ```
 
-
 ## $(twitchreward.redeemer_position.USERNAME_OR_ID)
 
 Returns the position for a specific user in the redemption queue. Replace `USERNAME_OR_ID` with another variable, such as [**$(user)**](/variables/user), or a hardcoded value. You may specifiy **either** a user ID, or username.


### PR DESCRIPTION
Forgot to document this argument. This also adds the error message case to the docs too, since Helix has a limitation where only the owning client ID is able to read the redemption queue, which restricts how useful this variable can be.