### PR TITLE
feat(mediarequest): add `mediarequest` default commands

### DIFF
--- a/docs/commands/default/clear.md
+++ b/docs/commands/default/clear.md
@@ -1,0 +1,21 @@
+---
+id: clear
+---
+
+# !clear
+
+Clears the entire media request queue.
+
+This command is only available to **Broadcasters** and **Moderators**.
+
+#### Parameters
+
+This command does not take any parameters.
+
+#### Example Output
+
+* `!clear`
+
+    ```
+    Cleared the current media request queue!
+    ```

--- a/docs/commands/default/index.md
+++ b/docs/commands/default/index.md
@@ -48,6 +48,17 @@ Default commands are built-in commands that come with every Fossabot installatio
 
 * [**!emotes**](emotes.md) - Displays channel emotes from various providers
 
+### Media Request Commands
+
+* [**!song**](song.md) - Displays the currently playing track in the media request queue
+* [**!sr**](sr.md) - Adds a track to the media request queue using a URL or search query
+* [**!clear**](clear.md) - Clears the entire media request queue
+* [**!songqueue**](songqueue.md) - Provides a link to view the current media request queue
+* [**!skip**](skip.md) - Skips the currently playing track in the media request queue
+* [**!volume**](volume.md) - Displays or sets the playback volume for media requests
+* [**!voteskip**](voteskip.md) - Votes to skip the currently playing track
+* [**!wrongsong**](wrongsong.md) - Removes your most recently requested track from the media request queue
+
 ### Management Commands
 
 * [**!addcmd**](addcmd.md) - Creates a new custom command

--- a/docs/commands/default/skip.md
+++ b/docs/commands/default/skip.md
@@ -1,0 +1,29 @@
+---
+id: skip
+---
+
+# !skip
+
+Skips the currently playing track in the media request queue.
+
+This command is only available to **Broadcasters** and **Moderators**.
+
+#### Parameters
+
+This command does not take any parameters.
+
+#### Example Output
+
+* `!skip`
+
+    ```
+    Skipped the currently playing track!
+    ```
+
+#### Error Output
+
+* In case there are no songs in the queue, returns the following:
+
+    ```
+    Error: No songs in queue
+    ```

--- a/docs/commands/default/song.md
+++ b/docs/commands/default/song.md
@@ -1,0 +1,33 @@
+---
+id: song
+---
+
+# !song
+
+Displays the currently playing track in the media request queue.
+
+#### Parameters
+
+This command does not take any parameters.
+
+#### Example Output
+
+* `!song`
+
+    ```
+    Rick Astley - Never Gonna Give You Up, requested by Aiden https://youtu.be/dQw4w9WgXcQ
+    ```
+
+* `!song` (when track is from backup playlist)
+
+    ```
+    Rick Astley - Never Gonna Give You Up, from backup playlist https://youtu.be/dQw4w9WgXcQ
+    ```
+
+#### Error Output
+
+* In case no song is currently playing, returns the following:
+
+    ```
+    No song is playing
+    ```

--- a/docs/commands/default/songqueue.md
+++ b/docs/commands/default/songqueue.md
@@ -1,0 +1,19 @@
+---
+id: songqueue
+---
+
+# !songqueue
+
+Provides a link to view the current media request queue.
+
+#### Parameters
+
+This command does not take any parameters.
+
+#### Example Output
+
+* `!songqueue`
+
+    ```
+    View the current media request queue: https://fossa.bot/channelname/mediarequest
+    ```

--- a/docs/commands/default/sr.md
+++ b/docs/commands/default/sr.md
@@ -1,0 +1,65 @@
+---
+id: sr
+---
+
+# !sr
+
+Adds a track to the media request queue using a URL or search query.
+
+#### Parameters
+
+This command takes **one** *required* parameter:
+
+1. **URL or search query** - A YouTube or SoundCloud URL, or a search query to find a track on YouTube
+
+#### Example Output
+
+* `!sr https://youtu.be/dQw4w9WgXcQ`
+
+    ```
+    Added "Rick Astley - Never Gonna Give You Up" to the queue at position #1 (~now)
+    ```
+
+* `!sr https://youtu.be/dQw4w9WgXcQ`
+
+    ```
+    Added "Rick Astley - Never Gonna Give You Up" to the queue at position #5 (~2m 30s)
+    ```
+
+* `!sr never gonna give you up`
+
+    ```
+    Added "Rick Astley - Never Gonna Give You Up" to the queue at position #3 (~1m 15s)
+    ```
+
+#### Error Output
+
+* In case no parameter is provided, returns the following:
+
+    ```
+    Usage: !sr <URL or search query>
+    ```
+
+* In case media request is disabled, returns the following:
+
+    ```
+    Error: Media request is currently disabled.
+    ```
+
+* In case a search query is used but YouTube is disabled, returns the following:
+
+    ```
+    Error: Using search queries is only supported on YouTube, which has been disabled by the broadcaster.
+    ```
+
+* In case an invalid URL is provided, returns the following:
+
+    ```
+    Error: Not a valid YouTube or SoundCloud URL
+    ```
+
+* In case no valid results are found for a search query, returns the following:
+
+    ```
+    Error: No valid results found on YouTube for that search query.
+    ```

--- a/docs/commands/default/volume.md
+++ b/docs/commands/default/volume.md
@@ -1,0 +1,37 @@
+---
+id: volume
+---
+
+# !volume
+
+Displays or sets the playback volume for media requests.
+
+This command is only available to **Broadcasters** and **Moderators**.
+
+#### Parameters
+
+This command takes **one** *optional* parameter:
+
+1. **Volume** - A number between 0 and 100 representing the playback volume percentage
+
+#### Example Output
+
+* `!volume`
+
+    ```
+    current volume: 75%
+    ```
+
+* `!volume 50`
+
+    ```
+    changed volume to 50%!
+    ```
+
+#### Error Output
+
+* In case an invalid volume value is provided, returns the following:
+
+    ```
+    Usage: !volume <0-100>
+    ```

--- a/docs/commands/default/voteskip.md
+++ b/docs/commands/default/voteskip.md
@@ -1,0 +1,33 @@
+---
+id: voteskip
+---
+
+# !voteskip
+
+Votes to skip the currently playing track. The track will be skipped once the required number of votes is reached.
+
+#### Parameters
+
+This command does not take any parameters.
+
+#### Example Output
+
+* `!voteskip` (when more votes are needed)
+
+    ```
+    UserName voted to skip this track. 3 votes are required to skip!
+    ```
+
+* `!voteskip` (when enough votes are reached)
+
+    ```
+    ⏭️ skipping "Artist Name - Song Title"...
+    ```
+
+#### Error Output
+
+* In case no track is currently playing, returns the following:
+
+    ```
+    Error: Cannot voteskip when there are no tracks playing.
+    ```

--- a/docs/commands/default/wrongsong.md
+++ b/docs/commands/default/wrongsong.md
@@ -1,0 +1,27 @@
+---
+id: wrongsong
+---
+
+# !wrongsong
+
+Removes your most recently requested track from the media request queue.
+
+#### Parameters
+
+This command does not take any parameters.
+
+#### Example Output
+
+* `!wrongsong`
+
+    ```
+    Removed "Rick Astley - Never Gonna Give You Up" from the media request queue
+    ```
+
+#### Error Output
+
+* In case your track cannot be found in the queue, returns the following:
+
+    ```
+    Error: Could not find your track in the media request queue
+    ```


### PR DESCRIPTION
Adds missing media request commands to the docs site, mostly generated with AI